### PR TITLE
missing key exception

### DIFF
--- a/lib/api_cache/moneta_store.rb
+++ b/lib/api_cache/moneta_store.rb
@@ -23,7 +23,9 @@ class APICache
 
     # Does a given key exist in the cache?
     def exists?(key)
-      @moneta.key?(key)
+      # double-check to ensure both keys are there
+      # really should not have outside influence but in this case we do
+      @moneta.key?(key) && @moneta.key?("#{key}_created_at")
     end
 
     # Has a given time passed since the key was set?

--- a/spec/monteta_store_spec.rb
+++ b/spec/monteta_store_spec.rb
@@ -29,6 +29,15 @@ describe APICache::MonetaStore do
     @store.expired?('foo', 1).should be_true
   end
 
+  it "should return false for exists? if created_at key is missing" do
+    @store.set("k", "v")
+    @store.exists?("k").should == true
+
+    @moneta.delete("k_created_at")
+
+    @store.exists?("k").should == false
+  end
+
   context "after delete" do
 
     it "should no longer exist" do


### PR DESCRIPTION
With both redis and memcached's default behavior of expiring keys when full, APICache sometimes throws exceptions when the key containing data is present but not the key w/the expiration date.

This patch simply ensures both keys are present when looking them up.

Two lookups doesn't seem ideal but is there a better solution for this behavior?
