### PR TITLE
Modified Markdown to support new Moneta Syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ APICache allows any API client library to be easily wrapped with a robust cachin
     
     # Use a proper store
     require 'moneta'
-    require 'moneta/memcache'
-    APICache.store = Moneta::Memcache.new(:server => "localhost")
+    APICache.store = Moneta.new(:Memcached)
     
     # Wrap an API, and handle the failure case
     


### PR DESCRIPTION
Hi Martyn,

  I've updated the markdown to support the new Moneta syntax. The old version no longer works as Memcache is no longer in the Moneta package but instead the adapters package. Each adapter is loaded through a factory which reads the symbol passed in the constructor.
