### PR TITLE
Fix DalliStore TypeError/Memcached Eviction Bug

### DIFF
--- a/lib/api_cache/dalli_store.rb
+++ b/lib/api_cache/dalli_store.rb
@@ -28,6 +28,7 @@ class APICache
 
     # Has a given time passed since the key was set?
     def expired?(key, timeout)
+      return true unless exists?("#{key}_created_at")
       Time.now - @dalli.get("#{key}_created_at") > timeout
     end
   end


### PR DESCRIPTION
In situations where Memcached evicts "#{key}_created_at" but not "key", you get a "TypeError: can't convert nil into an exact number" error from DalliStore#expired? because the value of @dalli.get("#{key}_created_at"), nil, can be subtracted from Time.now in line 32 of dalli_store.rb. This fixes that error by returning true if "#{key}_created_at" doesn't exist. This seems reasonable, since if we don't know the time the key was created, it's only safe to assume it's expired.
